### PR TITLE
#179452774: shepherd-migration-concourse-github-rate-limit

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,6 +38,7 @@ resources:
   # Used for setting status on commit
   - name: git-status
     type: github-status
+    check_every: 1h
     source:
       branch: main
       repository: Shimmur/elixir-lib-cookie-cutter


### PR DESCRIPTION
[179452774] shepherd-migration-concourse-github-rate-limit
This PR should hopefully fix the Github rate limit issues concourse has been facing.
Once merged please run:
`fly set-pipeline --pipeline PIPELINE_NAME --config ./ci/pipeline.yml`
to update your ci job.
Link to [story](https://www.pivotaltracker.com/story/show/179452774)

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖