### PR TITLE
#181537245: Update pipeline.yml and switch concourse-dind container version tag to 703b580

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,7 +49,7 @@ resources:
     type: docker-image
     source:
       repository: quay.io/shimmur/concourse-dind
-      tag: "24969e1"
+      tag: 703b580
       username: ((quayio.username))
       password: ((quayio.password))
 


### PR DESCRIPTION
[181537245] Update pipeline.yml and change the concourse-dind container to `703b580`
This new build container upgrades Docker to `v20.10.x`
Once merged please run `fly set-pipeline --pipeline PIPELINE_NAME --config ./ci/pipeline.yml`
to update your `ci` job.
https://www.pivotaltracker.com/story/show/181537245

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖