### PR TITLE
Match OTP/Elixir versions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp: 24.1
+          - otp: 24.3
             elixir: 1.13.4
             coverage: true
             lint: true


### PR DESCRIPTION
### What does this do on a high level?
Ensures Elixir versions specified in CI ascent with OTP versions.

### How was this change made?
This was a quick set of edits to how we specify language versions in `.github/workflows/main.yml`.

### Why is this change necessary?
_It just don't seem right_

CI checks for Elixir 1.11 were run against OTP-23, while the Elixir 1.12 checks were being run against OTP-22. This was backwards for how the Elixir advances with OTP.

<!-- This is a requirement of ticket [ticket_number](ticket_link).  -->


### How will this be verified?
- [ ] The PR includes new tests
- [X] Current test suite covers functionality
- [ ] This has been tested locally
- [ ] This has been tested in `dev`

### Any additional information or special handling required on this PR? 
<!-- - [ ] This requires [configuration changes](link_to_deploy_configs).  -->

_motivational imagery_
![Infomercial footage -- man walks strangely and looks skeptically at shoes in a box](https://media.giphy.com/media/14mu60gk80cHrG/giphy.gif)

