### PR TITLE
Support OTP 26.2 and elixir 1.16.0 for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - otp: 25.1
-            elixir: 1.14.2
+          - otp: 26.2
+            elixir: 1.16.0
             coverage: true
             lint: true
+          - otp: 26.2
+            elixir: 1.15.7
+          - otp: 25.3
+            elixir: 1.14.5
           - otp: 24.3
             elixir: 1.13.4
           - otp: 23.3


### PR DESCRIPTION
### What does this do on a high level?
This adds checks to this library's CI for the following versions:
- OTP 26.2 and Elixir 1.15.7
- OTP 26.2 and Elixir 1.16.0
- Bump Elixir 1.14 version from `1.14.2` to `1.14.5`

### How was this change made?
I added new entries to the `matrix` field in `main.yml` for the github configuration.

### Why is this change necessary?
This library should keep up with new versions of elixir so as to remain relevant.
<!-- This is a requirement of ticket [ticket_number](ticket_link).  -->


### How will this be verified?
- [ ] The PR includes new tests
- [X] Current test suite covers functionality
- [ ] This has been tested locally
- [ ] This has been tested in `dev`

### Any additional information or special handling required on this PR? 
<!-- - [ ] This requires [configuration changes](link_to_deploy_configs).  -->

_motivational imagery_
![a chimpanzee irons clothes](https://media.giphy.com/media/ENth1428H9YBO/giphy.gif)

