### PR TITLE
Update Ubuntu to 20.04 to fix test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Test (Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This will allow github actions test runners to work again.

### What does this do on a high level?
Updates the version of Ubuntu.

### How was this change made?
With a keyboard and positive intent.

### Why is this change necessary?
Currently the github actions has stopped working, preventing the test runners from working on any new pull requests.


### How will this be verified?
Alas, this is a github specific change and can only be tested via the pull request.

### Any additional information or special handling required on this PR? 
<!-- - [ ] This requires [configuration changes](link_to_deploy_configs).  -->

_motivational imagery_
![man running on treadmill, arms extended towards suspended donut](https://media.giphy.com/media/cmx15yYvf32w3Myo6i/giphy.gif?cid=790b7611en0uc4wxd7kkgtsn7417wpe4iv5x1o7pqfv6d9fc&ep=v1_gifs_search&rid=giphy.gif&ct=g)

