### PR TITLE
Set README.md as content for hex_doc index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## ## [1.2.1] - 2024-02-11
+- Update documentation config for better hex_doc experience
+
 ## [1.2.0] - 2024-02-07
 - Update all dependencies
 - Support Elixir 1.15.x and 1.16.x

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CheckerCab.MixProject do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.2.1"
 
   def project do
     [
@@ -21,6 +21,7 @@ defmodule CheckerCab.MixProject do
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
         plt_add_apps: [:ex_unit]
       ],
+      docs: docs(),
       package: package()
     ]
   end
@@ -48,6 +49,14 @@ defmodule CheckerCab.MixProject do
       {:ex_doc, "~> 0.31.2", only: :dev},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.18", only: :test}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      name: "CheckerCab",
+      extras: ["README.md", "CHANGELOG.md", "LICENSE"]
     ]
   end
 end


### PR DESCRIPTION
### What does this do on a high level?
This updates the docs config so that when navigating to `hexdocs.pm/checker_cab` the contents of the README will be presented first.

### How was this change made?
Added docs config into `mix.exs`

### Why is this change necessary?
I received feedback that it was confusing to navigate the docs on hexdocs.pm


### How will this be verified?
- [ ] The PR includes new tests
- [ ] Current test suite covers functionality
- [ ] This has been tested locally
- [ ] This has been tested in `dev`

### Any additional information or special handling required on this PR? 
<!-- - [ ] This requires [configuration changes](link_to_deploy_configs).  -->

_motivational imagery_
![Homer Simpson reading book and not understanding anything](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNmJzZTQ0dHV2Mzhqazd5dmN5bXgxa2Vybno5ajlwem5vdmZhamxiNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/3o6MbbwX2g2GA4MUus/giphy.gif)

