### PR TITLE
- Add protocol to allow custom type matching rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## ## [1.2.1] - 2024-02-11
+## [1.3.0] - 2024-02-11
+- Add protocol to allow custom type matching rules
+- Update README with example
+
+## [1.2.1] - 2024-02-11
 - Update documentation config for better hex_doc experience
 
 ## [1.2.0] - 2024-02-07

--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ def deps do
 end
 ```
 
+## Custom Type Matching
+The default implementation to compare values in CheckerCab is to use `==/2`.
+If you need to compare types where that won't work, you can add additional
+implementations for the CheckerCab.MatchTypes in your application.
+
+```elixir
+defimpl CheckerCab.MatchTypes, for: Decimal do
+  def values_match?(expected, actual) do
+    Decimal.equal?(expected, actual)
+  end
+end
+```
+
+You can then use `assert_values_for/1` as you normally would:
+
+```elixir
+    test "success: with equivalent Decimal values" do
+      expected = %{key1: Decimal.new("1.10")}
+      actual = %{key1: Decimal.new("1.1")}
+
+      input = [expected: expected, actual: actual, fields: Map.keys(expected)]
+
+      assert :ok == CheckerCab.assert_values_for(input)
+    end
+```
+
 ## Integrating into a test suite
 Import `CheckerCab` to your test case file:
 ```elixir

--- a/lib/checker_cab.ex
+++ b/lib/checker_cab.ex
@@ -168,8 +168,8 @@ defmodule CheckerCab do
     !match?({:ok, _}, expected) || !match?({:ok, _}, actual)
   end
 
-  defp mismatched?(%{expected: expected, actual: actual}) do
-    expected != actual
+  defp mismatched?(%{expected: {:ok, expected}, actual: {:ok, actual}}) do
+    not CheckerCab.MatchTypes.values_match?(expected, actual)
   end
 
   defp fetch_and_convert(map, field_name, opts) do

--- a/lib/match_types.ex
+++ b/lib/match_types.ex
@@ -1,0 +1,11 @@
+defprotocol CheckerCab.MatchTypes do
+  @fallback_to_any true
+  @spec values_match?(any(), any()) :: boolean()
+  def values_match?(expected, actual)
+end
+
+defimpl CheckerCab.MatchTypes, for: Any do
+  def values_match?(expected, actual) do
+    expected == actual
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,13 +1,14 @@
 defmodule CheckerCab.MixProject do
   use Mix.Project
 
-  @version "1.2.1"
+  @version "1.3.0"
 
   def project do
     [
       app: :checker_cab,
       version: @version,
       elixir: "~> 1.11",
+      elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
@@ -22,7 +23,8 @@ defmodule CheckerCab.MixProject do
         plt_add_apps: [:ex_unit]
       ],
       docs: docs(),
-      package: package()
+      package: package(),
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 
@@ -48,9 +50,13 @@ defmodule CheckerCab.MixProject do
       {:ecto, "~> 3.11"},
       {:ex_doc, "~> 0.31.2", only: :dev},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:excoveralls, "~> 0.18", only: :test}
+      {:excoveralls, "~> 0.18", only: :test},
+      {:decimal, "~> 2.0"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp docs do
     [

--- a/test/checker_cab_test.exs
+++ b/test/checker_cab_test.exs
@@ -299,7 +299,7 @@ defmodule CheckerCabTest do
     end
   end
 
-  describe "assert_values for with options" do
+  describe "assert_values_for with options" do
     test "success: with :convert_dates set to true" do
       datetime = DateTime.utc_now()
       date = datetime |> DateTime.to_date()
@@ -307,6 +307,17 @@ defmodule CheckerCabTest do
       actual = %{key1: DateTime.to_iso8601(datetime), key2: Date.to_iso8601(date)}
 
       input = [expected: expected, actual: actual, fields: Map.keys(expected), opts: [convert_dates: true]]
+
+      assert :ok == CheckerCab.assert_values_for(input)
+    end
+  end
+
+  describe "assert_values_for with custom matchers" do
+    test "success: with custom matchers" do
+      expected = %{key1: Decimal.new("1.10")}
+      actual = %{key1: Decimal.new("1.1")}
+
+      input = [expected: expected, actual: actual, fields: Map.keys(expected)]
 
       assert :ok == CheckerCab.assert_values_for(input)
     end

--- a/test/support/match_types_decimal_impl.ex
+++ b/test/support/match_types_decimal_impl.ex
@@ -1,0 +1,5 @@
+defimpl CheckerCab.MatchTypes, for: Decimal do
+  def values_match?(expected, actual) do
+    Decimal.equal?(expected, actual)
+  end
+end


### PR DESCRIPTION
NOTE: I'm super open to renaming everything that is added here. Naming is hard.

### What does this do on a high level?

This introduces a protocol to allow applications to define their own custom matching rules for specific data types. 


### How was this change made?

Adding a protocol and updating tests.


### Why is this change necessary?

This makes the library more flexible, leading to fewer cases where skip_fields are needed.


### How will this be verified?
- [X] The PR includes new tests
- [ ] Current test suite covers functionality
- [ ] This has been tested locally
- [ ] This has been tested in `dev`

### Any additional information or special handling required on this PR? 
nope

_motivational imagery_
![a compact disc tells a walkman that it isn't its type](https://media.giphy.com/media/SNg0cGHMm5GJ7JoENr/giphy.gif?cid=790b76112z2vl49e0rzrvhycnmwld9vpvbob2xygnao5818k&ep=v1_gifs_search&rid=giphy.gif&ct=g)

